### PR TITLE
Fixed typo in context menu

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -25,7 +25,7 @@
           "args"    : {"user_input" : "&"}
           },
           {
-          "caption" : "Vertial Bars ( | )",
+          "caption" : "Vertical Bars ( | )",
           "command" : "align_tab",
           "args"    : {"user_input" : "\\|"}
           },


### PR DESCRIPTION
In the *Align By* context menu it says *Vertial Bars* instead of *Vertical Bars*, and it bothers me probably way more than it should

Fix provided